### PR TITLE
SCC-2110 Improve App Invocation

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -23,14 +23,14 @@ def handle_event(event:, context:)
   event["Records"]
     .select { |record| record["eventSource"] == "aws:kinesis" }
     .each do |record|
-        decoded_record = parse_record(record)
+      decoded_record = parse_record(record)
 
-        unless decoded_record && should_process? decoded_record
-          record_results << decoded_record == nil ? [nil, 'ERROR'] : [decoded_record['id'], 'SKIPPING']
-          next
-        end
+      unless decoded_record && should_process? decoded_record
+        record_results << decoded_record == nil ? [nil, 'ERROR'] : [decoded_record['id'], 'SKIPPING']
+        next
+      end
 
-        record_results << process_record(decoded_record)
+      record_results << process_record(decoded_record)
     end
   
   return record_results

--- a/app.rb
+++ b/app.rb
@@ -1,11 +1,9 @@
 require 'json'
 require 'nypl_log_formatter'
 
-# require the `is_research` layer Bib class
-require '/opt/is-research-layer/lib/bib'
-
 require_relative 'lib/avro_decoder.rb'
 require_relative 'lib/bib_data_manager.rb'
+require_relative 'lib/platform_api_client.rb'
 
 def init
   return if $initialized
@@ -13,7 +11,6 @@ def init
   $logger = NyplLogFormatter.new(STDOUT, level: ENV['LOG_LEVEL'] || 'info')
   $platform_api = PlatformApiClient.new
   $avro_decoder = AvroDecoder.by_name('Bib')
-  $nypl_core = NyplCore.new
 
   $initialized = true
 end
@@ -21,29 +18,60 @@ end
 def handle_event(event:, context:)
   init
 
+  record_results = []
+
   event["Records"]
     .select { |record| record["eventSource"] == "aws:kinesis" }
     .each do |record|
-      avro_data = record["kinesis"]["data"]
+        decoded_record = parse_record(record)
 
-      decoded = $avro_decoder.decode avro_data
-      $logger.debug "Decoded bib", decoded
+        unless decoded_record && should_process? decoded_record
+          record_results << decoded_record == nil ? [nil, 'ERROR'] : [decoded_record['id'], 'SKIPPING']
+          next
+        end
 
-      return unless should_process? decoded
-      # make POST request to SHEP API
-      uri = URI(ENV['SHEP_API_BIBS_ENDPOINT'])
-
-      resp = Net::HTTP.post_form(uri, "data" => decoded.to_json)
-
-      if resp.code.to_i > 400
-        message = JSON.parse(resp.body)["message"]
-        log_message = "Bib #{decoded['nyplSource']} #{decoded['id']} not processed by Subject Heading (SHEP) API"
-        log_message += "; message: #{message}" if message
-        $logger.error log_message
-      end
-
-      $logger.info "Bib #{decoded['nyplSource']} #{decoded['id']} successfully processed by Subject Heading (SHEP) API" if resp.code.to_i == 201
+        record_results << process_record(decoded_record)
     end
+  
+  return record_results
+end
+
+def parse_record record
+  begin
+    avro_data = record["kinesis"]["data"]
+  rescue KeyError => e
+    $logger.error "Missing field in Kinesis message, unable to process #{e.message}"
+    return nil 
+  end
+
+  begin
+    decoded = $avro_decoder.decode avro_data
+    $logger.debug "Decoded bib", decoded
+  rescue AvroError => e
+    $logger.error "Record failed Avro validation for reason: #{e.message}"
+    return nil
+  end
+
+  return decoded
+end
+
+def process_record record
+  # make POST request to SHEP API
+  uri = URI(ENV['SHEP_API_BIBS_ENDPOINT'])
+
+  resp = Net::HTTP.post_form(uri, "data" => decoded.to_json)
+
+  if resp.code.to_i > 400
+    message = JSON.parse(resp.body)["message"]
+    log_message = "Bib #{decoded['nyplSource']} #{decoded['id']} not processed by Subject Heading (SHEP) API"
+    log_message += "; message: #{message}" if message
+    $logger.error log_message
+  end
+
+  $logger.debug "Response", { "resp": JSON.parse(resp.body)}
+
+  $logger.info "Bib #{decoded['nyplSource']} #{decoded['id']} successfully processed by Subject Heading (SHEP) API" if resp.code.to_i == 201
+  return [decoded['id'], 'SUCCESS']
 end
 
 def should_process? data
@@ -54,19 +82,14 @@ def is_research? data
   nypl_source = data['nyplSource']
   bib_id = data['id']
 
-  bib = Bib.new(nypl_source, bib_id)
-
   begin
-    is_research = bib.is_research?
-  rescue DeletedError => e
-    $logger.debug "Deleted bib #{bib_id}, will not process"
-    return false
-  rescue => e
-    $logger.warn "#{e.class}: #{e.message}; bib #{nypl_source} #{bib_id}"
+    research_status = $platform_api.get("bibs/#{nypl_source}/#{bib_id}/is-research")
+  rescue Exception => e
+    $logger.warn "Unexpected Error encountered #{e.message}"
     return false
   end
-
-  unless is_research
+  
+  unless research_status["isResearch"]
     $logger.debug "Circulating bib #{bib_id}, will not process"
     return false
   end
@@ -76,7 +99,13 @@ end
 
 def have_subject_headings_changed? data
   # discovery id can come from BibDataManager
-  bib_data = SHEP::BibDataManager.new(data)
+  begin
+    bib_data = SHEP::BibDataManager.new(data)
+  rescue BibDataManagerError => e
+    $logger.error "Unable to process record due to: #{e.message}"
+    return false
+  end
+
   incoming_tagged_subject_headings = bib_data.heading_data_mgrs.map(&:tagged_label).sort
 
   discovery_id = bib_data.discovery_id
@@ -85,9 +114,9 @@ def have_subject_headings_changed? data
   uri = URI("#{ENV['SHEP_API_BIBS_ENDPOINT']}#{discovery_id}/tagged_subject_headings")
   resp = Net::HTTP.get_response(uri)
 
-  not_found = resp.code == "404"
-
-  return not_found && incoming_tagged_subject_headings.length > 0 if not_found 
+  if resp.code == "404"
+    return not_found && incoming_tagged_subject_headings.length > 0
+  end
 
   unless resp.code == "200"
     $logger.warn "Unexpected result from SHEP API 'Bib#tagged_subject_headings' endpoint for bib #{discovery_id}. Will not process. Message: #{resp.message}"

--- a/lib/kms_client.rb
+++ b/lib/kms_client.rb
@@ -1,0 +1,22 @@
+require 'aws-sdk-kms'
+require 'base64'
+
+class KmsClient
+  @@kms = nil
+
+  def initialize
+    @kms = self.class.aws_kms_client
+  end
+
+  def decrypt(cipher)
+    # Assume value is base64 encoded:
+    decoded = Base64.decode64 cipher
+    decrypted = @kms.decrypt ciphertext_blob: decoded
+    decrypted[:plaintext]
+  end
+
+  def self.aws_kms_client
+    @@kms = Aws::KMS::Client.new(region: 'us-east-1', stub_responses: ENV['APP_ENV'] == 'test') if @@kms.nil?
+    @@kms
+  end
+end

--- a/lib/platform_api_client.rb
+++ b/lib/platform_api_client.rb
@@ -1,0 +1,90 @@
+require 'net/http'
+require 'net/https'
+require 'uri'
+
+require_relative 'kms_client'
+
+class PlatformApiClient
+  def initialize
+    raise 'Missing config: NYPL_OAUTH_ID is unset' if ENV['NYPL_OAUTH_ID'].nil? || ENV['NYPL_OAUTH_ID'].empty?
+    raise 'Missing config: NYPL_OAUTH_SECRET is unset' if ENV['NYPL_OAUTH_SECRET'].nil? || ENV['NYPL_OAUTH_SECRET'].empty?
+
+    kms_client = KmsClient.new
+    @client_id = kms_client.decrypt(ENV['NYPL_OAUTH_ID'])
+    @client_secret = kms_client.decrypt(ENV['NYPL_OAUTH_SECRET'])
+
+    @oauth_site = ENV['NYPL_OAUTH_URL']
+  end
+
+  def get (path, options = {})
+    options = {
+      authenticated: true
+    }.merge options
+
+    authenticate! if options[:authenticated]
+
+    uri = URI.parse("#{ENV['PLATFORM_API_BASE_URL']}#{path}")
+
+    $logger.debug "Getting from platform api", { uri: uri }
+
+    begin
+      request = Net::HTTP::Get.new(uri)
+      request["Authorization"] = "Bearer #{@access_token}" if options[:authenticated]
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme === 'https') do |http|
+        http.request(request)
+      end
+
+      $logger.debug "Got platform api response", { code: response.code, body: response.body }
+
+      parse_json_response response
+
+    rescue Exception => e
+      raise StandardError.new(e), "Failed to retrieve #{path} #{e.message}"
+    end
+  end
+
+  private
+
+  def parse_json_response (response)
+    if response.code == "200"
+      JSON.parse(response.body)
+    elsif response.code == "404"
+      JSON.parse(response.body)
+    elsif response.code == "401"
+      # Likely an expired access-token; Wipe it for next run
+      @access_token = nil
+    else
+      raise "Error interpretting response (#{response.code}): #{response.body}"
+      {}
+    end
+  end
+
+  # Authorizes the request.
+  def authenticate!
+    # NOOP if we've already authenticated
+    return nil if ! @access_token.nil?
+
+    uri = URI.parse("#{@oauth_site}oauth/token")
+    request = Net::HTTP::Post.new(uri)
+    request.basic_auth(@client_id, @client_secret)
+    request.set_form_data(
+      "grant_type" => "client_credentials"
+    )
+
+    req_options = {
+      use_ssl: uri.scheme == "https",
+      request_timeout: 500
+    }
+
+    response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+      http.request(request)
+    end
+
+    if response.code == '200'
+      @access_token = JSON.parse(response.body)["access_token"]
+    else
+      nil
+    end
+  end
+
+end

--- a/sam.dev.yml
+++ b/sam.dev.yml
@@ -5,7 +5,7 @@ Description: 'subject-heading-services'
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 20
+    Timeout: 60
 
 Resources:
   SubjectHeadingPoster:
@@ -17,17 +17,17 @@ Resources:
         Stream:
           Type: Kinesis
           Properties:
-            Stream: arn:aws:kinesis:us-east-1:946183545209:stream/Bib-qa
-            BatchSize: 100
+            Stream: arn:aws:kinesis:us-east-1:224280085904:stream/Bib
+            BatchSize: 10
             StartingPosition: LATEST
-      Layers:
-        - arn:aws:lambda:us-east-1:946183545209:layer:isResearchLayer:8
+            MaximumRetryAttempts: 3
+            BisectBatchOnFunctionError: True
       Environment:
         Variables:
-          PLATFORM_API_BASE_URL: https://qa-platform.nypl.org/api/v0.1/
+          PLATFORM_API_BASE_URL: https://dev-platform.nypl.org/api/v0.1/
           NYPL_OAUTH_URL: https://isso.nypl.org/
           LOG_LEVEL: debug
           NYPL_OAUTH_ID: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGswaQYJKoZIhvcNAQcGoFwwWgIBADBVBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDGwps2kAQ2rowHoTfAIBEIAo4NrJQ8TDmuTM8fD+Ke9RAaiLxFkE4Z1SvGE5gkSsIJ0966etTQ2+qw==
           NYPL_OAUTH_SECRET: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAzqpSpOyAs6z7xuhIYCARCAQxQmBeJEIuw09MFA+nmoqMfE7ZvqsfLUCsOlDApqRhiEM3M3pfWOaoK7kTKR+37sgrYqSkZTZuMWGzzFTXa2z0QKB7c=
           NYPL_CORE_S3_BASE_URL: https://s3.amazonaws.com/nypl-core-objects-mapping-production/
-          SHEP_API_BIBS_ENDPOINT: http://shep-api-new-development.us-east-1.elasticbeanstalk.com/api/v0.1/bibs/
+          SHEP_API_BIBS_ENDPOINT: http://discovery-ui-shep-development.us-east-1.elasticbeanstalk.com//api/v0.1/bibs/

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -5,7 +5,7 @@ Description: 'subject-heading-services'
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 10
+    Timeout: 30
 
 Resources:
   SubjectHeadingPoster:
@@ -20,8 +20,6 @@ Resources:
             Stream: arn:aws:kinesis:us-east-1:946183545209:stream/Bib-qa
             BatchSize: 100
             StartingPosition: LATEST
-      Layers:
-        - arn:aws:lambda:us-east-1:946183545209:layer:isResearchLayer:8
       Environment:
         Variables:
           PLATFORM_API_BASE_URL: https://platform.nypl.org/api/v0.1/
@@ -30,4 +28,4 @@ Resources:
           NYPL_OAUTH_ID: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGswaQYJKoZIhvcNAQcGoFwwWgIBADBVBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDGwps2kAQ2rowHoTfAIBEIAo4NrJQ8TDmuTM8fD+Ke9RAaiLxFkE4Z1SvGE5gkSsIJ0966etTQ2+qw==
           NYPL_OAUTH_SECRET: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAzqpSpOyAs6z7xuhIYCARCAQxQmBeJEIuw09MFA+nmoqMfE7ZvqsfLUCsOlDApqRhiEM3M3pfWOaoK7kTKR+37sgrYqSkZTZuMWGzzFTXa2z0QKB7c=
           NYPL_CORE_S3_BASE_URL: https://s3.amazonaws.com/nypl-core-objects-mapping-production/
-          SHEP_API_BIBS_ENDPOINT: http://docker.for.mac.localhost:8080/api/v0.1/bibs/
+          SHEP_API_BIBS_ENDPOINT: http://docker.for.mac.localhost:3000/api/v0.1/bibs/

--- a/sam.production.yml
+++ b/sam.production.yml
@@ -5,7 +5,7 @@ Description: 'subject-heading-services'
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 10
+    Timeout: 60 
 
 Resources:
   SubjectHeadingPoster:
@@ -18,10 +18,11 @@ Resources:
           Type: Kinesis
           Properties:
             Stream: arn:aws:kinesis:us-east-1:946183545209:stream/Bib-qa
-            BatchSize: 100
+            BatchSize: 10
             StartingPosition: LATEST
-      Layers:
-        - arn:aws:lambda:us-east-1:946183545209:layer:isResearchLayer:8
+            MaximumRetryAttempts: 3
+            BisectBatchOnFunctionError: True
+            DestinationConfig: arn:aws:sns:us-east-1:946183545209:SHEP
       Environment:
         Variables:
           PLATFORM_API_BASE_URL: https://platform.nypl.org/api/v0.1/

--- a/sam.qa.yml
+++ b/sam.qa.yml
@@ -23,8 +23,6 @@ Resources:
             MaximumRetryAttempts: 3
             BisectBatchOnFunctionError: True
             DestinationConfig: arn:aws:sns:us-east-1:946183545209:SHEP
-      Layers:
-        - arn:aws:lambda:us-east-1:946183545209:layer:isResearchLayer:8
       Environment:
         Variables:
           PLATFORM_API_BASE_URL: https://qa-platform.nypl.org/api/v0.1/

--- a/sam.qa.yml
+++ b/sam.qa.yml
@@ -5,7 +5,7 @@ Description: 'subject-heading-services'
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 20
+    Timeout: 60
 
 Resources:
   SubjectHeadingPoster:
@@ -18,8 +18,11 @@ Resources:
           Type: Kinesis
           Properties:
             Stream: arn:aws:kinesis:us-east-1:946183545209:stream/Bib-qa
-            BatchSize: 100
+            BatchSize: 10
             StartingPosition: LATEST
+            MaximumRetryAttempts: 3
+            BisectBatchOnFunctionError: True
+            DestinationConfig: arn:aws:sns:us-east-1:946183545209:SHEP
       Layers:
         - arn:aws:lambda:us-east-1:946183545209:layer:isResearchLayer:8
       Environment:


### PR DESCRIPTION
This is a slight refactor to improve how the poster is invoked. This does not touch any of the logic of how the records are parsed or tested. These updates are:

- Removed the `is-research` layer in favor of calling the API that provides the same service
- Refactored the `handle_event` method so that errors can be handled more accurately in smaller methods
- Added a return to `handle_event` so that the outcome of each batch will be reflected in the logs
- Added some additional error handling so that malformed records do not block the processing of a batch

Additionally some environment configuration has been updated in the SAM files to make sure that batches are a processable size and that errors are dumped somewhere that they can be reviewed.