### PR TITLE
SCC-2079 Make function multithreaded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ deploy:
   region: us-east-1
   role: arn:aws:iam::224280085904:role/lambda_basic_execution
   runtime: ruby2.5
+  timeout: 60
   module_name: app
   handler_name: handle_event
   environment_variables:
@@ -42,6 +43,7 @@ deploy:
   region: us-east-1
   role: arn:aws:iam::946183545209:role/lambda-full-access
   runtime: ruby2.5
+  timeout: 60
   module_name: app
   handler_name: handle_event
   environment_variables:

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'avro'
+gem 'aws-sdk-kms'
 gem 'nypl_log_formatter'
+gem 'parallel'
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,12 +5,26 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     avro (1.9.2)
       multi_json
+    aws-eventstream (1.1.0)
+    aws-partitions (1.341.0)
+    aws-sdk-core (3.103.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.36.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.2.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     hashdiff (1.0.1)
+    jmespath (1.4.0)
     multi_json (1.14.1)
     nypl_log_formatter (0.1.3)
+    parallel (1.19.2)
     public_suffix (4.0.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -36,7 +50,9 @@ PLATFORMS
 
 DEPENDENCIES
   avro
+  aws-sdk-kms
   nypl_log_formatter
+  parallel
   rspec
   webmock
 

--- a/sam.dev.yml
+++ b/sam.dev.yml
@@ -6,13 +6,13 @@ Description: 'subject-heading-services'
 Globals:
   Function:
     Timeout: 60
+    Handler: app.handle_event
+    Runtime: ruby2.5
 
 Resources:
   SubjectHeadingPoster:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
-      Handler: app.handle_event
-      Runtime: ruby2.5
       Events:
         Stream:
           Type: Kinesis

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -1,178 +1,178 @@
 require 'spec_helper'
 
 describe "handler" do
-    describe "#init" do
-        before(:each) {
-            allow(AvroDecoder).to receive(:by_name).with("Bib")
-        }
-        it "should set initialized to true" do
-            expect(AvroDecoder).to receive(:by_name).with("Bib")
-            init
-            expect($initialized).to eq(true)
-        end
+  describe "#init" do
+    before(:each) {
+      allow(AvroDecoder).to receive(:by_name).with("Bib")
+    }
+    it "should set initialized to true" do
+      expect(AvroDecoder).to receive(:by_name).with("Bib")
+      init
+      expect($initialized).to eq(true)
+    end
+  end
+
+  describe "#handle_event" do
+    it "should process all events passed in" do
+      test_records = [{"eventSource" => "aws:kinesis", :rec => 1}, {"eventSource" => "aws:kinesis", :rec => 2}]
+      allow(Parallel).to receive(:map).with(test_records, in_processes: 3).and_return([true, true])
+  
+      records_status = handle_event(event: {"Records" => test_records}, context: {})
+      expect(records_status).to eq([true, true])
     end
 
-    describe "#handle_event" do
-        it "should process all events passed in" do
-            test_records = [{"eventSource" => "aws:kinesis", :rec => 1}, {"eventSource" => "aws:kinesis", :rec => 2}]
-            allow(Parallel).to receive(:map).with(test_records, in_processes: 3).and_return([true, true])
+    it "should do nothing if no records are present in the event" do
+      test_records = []
+      records_status = handle_event(event: {"Records" => test_records}, context: {})
+      expect(records_status).to eq([])
+    end
+  end
+
+  describe "#process_record" do
+    before(:each) {
+      @record = {"id" => 1}
+    }
+
+    it "should invoke store_record if record is processable" do
+      allow(self).to receive(:parse_record).and_return(@record)
+      allow(self).to receive(:should_process?).with(@record).and_return(true)
+      allow(self).to receive(:store_record).with(@record).and_return(true)
+
+      result = process_record(@record)
+
+      expect(result).to eq(true)
+    end
+
+    it "should return SKIPPING STATUS if should_process? is false" do
+      allow(self).to receive(:parse_record).and_return(@record)
+      allow(self).to receive(:should_process?).with(@record).and_return(false)
+
+      result = process_record(@record)
+
+      expect(result).to eq([1, 'SKIPPING'])
+    end
+
+    it "should return ERROR if decoded_record is nill" do
+      allow(self).to receive(:parse_record).and_return(nil)
+
+      result = process_record(@record)
+
+      expect(result).to eq([nil, 'ERROR'])
+    end
+  end
+  
+  describe "#parse_record" do
+    before(:each) {
+      $avro_decoder = double()
+      allow($avro_decoder).to receive(:decode)
+    }
+
+    it "should return an object if avro decoding succeeds" do
+      valid_record = {
+        "kinesis" => {
+          "data" => {"encoded" => {:id => 1, :title => "testing"}}
+        }
+      }
+
+      expect($avro_decoder).to receive(:decode).and_return(valid_record["kinesis"]["data"]["encoded"])
+
+      decoded_record = parse_record(valid_record)
+
+      expect(decoded_record[:id]).to eq(1)
+      expect(decoded_record[:title]).to eq("testing")
+    end
+
+    it "should raise an error if avro fails to decode a record" do
+      valid_record = {
+        "kinesis" => {
+          "data" => {"encoded" => {:id => 1, :title => "testing"}}
+        }
+      }
+
+      expect($avro_decoder).to receive(:decode).and_raise(AvroError.new("testing"))
+
+      decoded_record = parse_record(valid_record)
+
+      expect(decoded_record).to eq(nil)
+    end
+
+    it "should raise an error if the document is malformed" do
+      invalid_record = {}
+      decoded_record = parse_record(invalid_record)
+      expect(decoded_record).to eq(nil)
+    end
+  end
+
+  describe "#store_record" do
+    before(:each) { allow(Net::HTTP).to receive(:post_form) }
+
+    it "should return success if SHEP API returns 200" do
+      resp = double("response", :code => '200', :body => JSON.dump({'message' => 'success'}))
+      expect(Net::HTTP).to receive(:post_form).and_return(resp)
+
+      output = store_record({'id' => 1, 'nypl-source' => 'nypl-test'})
+      expect(output).to eq([1, 'SUCCESS'])
+    end
+
+    it "should return error if SHEP API returns 400+" do
+      resp = double("response", :code => '403', :body => JSON.dump({'message' => 'error'}))
+      expect(Net::HTTP).to receive(:post_form).and_return(resp)
+
+      output = store_record({'id' => 1, 'nypl-source' => 'nypl-test'})
+      expect(output).to eq([1, 'ERROR'])
+    end
+  end
+
+  describe "#should_process?" do
+    before(:each) {
+      allow(self).to receive(:is_research?)
+      allow(self).to receive(:have_subject_headings_changed?)
+    }
     
-            records_status = handle_event(event: {"Records" => test_records}, context: {})
-            expect(records_status).to eq([true, true])
-        end
+    it "should return true if is_research and have_subject_headings_changed return true" do
+      expect(self).to receive(:is_research?).with('data').and_return(true)
+      expect(self).to receive(:have_subject_headings_changed?).with('data').and_return(true)
 
-        it "should do nothing if no records are present in the event" do
-            test_records = []
-            records_status = handle_event(event: {"Records" => test_records}, context: {})
-            expect(records_status).to eq([])
-        end
-    end
-
-    describe "#process_record" do
-        before(:each) {
-            @record = {"id" => 1}
-        }
-
-        it "should invoke store_record if record is processable" do
-            allow(self).to receive(:parse_record).and_return(@record)
-            allow(self).to receive(:should_process?).with(@record).and_return(true)
-            allow(self).to receive(:store_record).with(@record).and_return(true)
-
-            result = process_record(@record)
-
-            expect(result).to eq(true)
-        end
-
-        it "should return SKIPPING STATUS if should_process? is false" do
-            allow(self).to receive(:parse_record).and_return(@record)
-            allow(self).to receive(:should_process?).with(@record).and_return(false)
-
-            result = process_record(@record)
-
-            expect(result).to eq([1, 'SKIPPING'])
-        end
-
-        it "should return ERROR if decoded_record is nill" do
-            allow(self).to receive(:parse_record).and_return(nil)
-
-            result = process_record(@record)
-
-            expect(result).to eq([nil, 'ERROR'])
-        end
+      expect(should_process?('data')).to eq(true)
     end
     
-    describe "#parse_record" do
-        before(:each) {
-            $avro_decoder = double()
-            allow($avro_decoder).to receive(:decode)
-        }
+    it "should return false if is_research is false and not call have_subject_headings_changed?" do
+      expect(self).to receive(:is_research?).with('data').and_return(false)
+      expect(self).to_not receive(:have_subject_headings_changed?).with('data')
 
-        it "should return an object if avro decoding succeeds" do
-            valid_record = {
-                "kinesis" => {
-                    "data" => {"encoded" => {:id => 1, :title => "testing"}}
-                }
-            }
+      expect(should_process?('data')).to eq(false)
+    end
+    
+    it "should return false if have_subject_headings_changed returns false" do
+      expect(self).to receive(:is_research?).with('data').and_return(true)
+      expect(self).to receive(:have_subject_headings_changed?).with('data').and_return(false)
 
-            expect($avro_decoder).to receive(:decode).and_return(valid_record["kinesis"]["data"]["encoded"])
+      expect(should_process?('data')).to eq(false)
+    end
+  end
 
-            decoded_record = parse_record(valid_record)
+  describe "#is_research?" do
+    before(:each) {
+      allow($platform_api).to receive(:get)
+    }
 
-            expect(decoded_record[:id]).to eq(1)
-            expect(decoded_record[:title]).to eq("testing")
-        end
-
-        it "should raise an error if avro fails to decode a record" do
-            valid_record = {
-                "kinesis" => {
-                    "data" => {"encoded" => {:id => 1, :title => "testing"}}
-                }
-            }
-
-            expect($avro_decoder).to receive(:decode).and_raise(AvroError.new("testing"))
-
-            decoded_record = parse_record(valid_record)
-
-            expect(decoded_record).to eq(nil)
-        end
-
-        it "should raise an error if the document is malformed" do
-            invalid_record = {}
-            decoded_record = parse_record(invalid_record)
-            expect(decoded_record).to eq(nil)
-        end
+    it "should return true if API response is true" do
+      expect($platform_api).to receive(:get).with('bibs/test-nypl/1/is-research').and_return({"isResearch" => true})
+      expect(is_research?({'nyplSource' => 'test-nypl', 'id' => '1'})).to eq(true)
     end
 
-    describe "#store_record" do
-        before(:each) { allow(Net::HTTP).to receive(:post_form) }
-
-        it "should return success if SHEP API returns 200" do
-            resp = double("response", :code => '200', :body => JSON.dump({'message' => 'success'}))
-            expect(Net::HTTP).to receive(:post_form).and_return(resp)
-
-            output = store_record({'id' => 1, 'nypl-source' => 'nypl-test'})
-            expect(output).to eq([1, 'SUCCESS'])
-        end
-
-        it "should return error if SHEP API returns 400+" do
-            resp = double("response", :code => '403', :body => JSON.dump({'message' => 'error'}))
-            expect(Net::HTTP).to receive(:post_form).and_return(resp)
-
-            output = store_record({'id' => 1, 'nypl-source' => 'nypl-test'})
-            expect(output).to eq([1, 'ERROR'])
-        end
+    it "should return false if API response is false" do
+      expect($platform_api).to receive(:get).with('bibs/test-nypl/1/is-research').and_return({"isResearch" => false})
+      expect(is_research?({'nyplSource' => 'test-nypl', 'id' => '1'})).to eq(false)
     end
 
-    describe "#should_process?" do
-        before(:each) {
-            allow(self).to receive(:is_research?)
-            allow(self).to receive(:have_subject_headings_changed?)
-        }
-        
-        it "should return true if is_research and have_subject_headings_changed return true" do
-            expect(self).to receive(:is_research?).with('data').and_return(true)
-            expect(self).to receive(:have_subject_headings_changed?).with('data').and_return(true)
-
-            expect(should_process?('data')).to eq(true)
-        end
-        
-        it "should return false if is_research is false and not call have_subject_headings_changed?" do
-            expect(self).to receive(:is_research?).with('data').and_return(false)
-            expect(self).to_not receive(:have_subject_headings_changed?).with('data')
-
-            expect(should_process?('data')).to eq(false)
-        end
-        
-        it "should return false if have_subject_headings_changed returns false" do
-            expect(self).to receive(:is_research?).with('data').and_return(true)
-            expect(self).to receive(:have_subject_headings_changed?).with('data').and_return(false)
-
-            expect(should_process?('data')).to eq(false)
-        end
+    it "should return false if API request receives an error" do
+      expect($platform_api).to receive(:get).with('bibs/test-nypl/1/is-research').and_raise(Exception.new)
+      expect(is_research?({'nyplSource' => 'test-nypl', 'id' => '1'})).to eq(false)
     end
+  end
 
-    describe "#is_research?" do
-        before(:each) {
-            allow($platform_api).to receive(:get)
-        }
-
-        it "should return true if API response is true" do
-            expect($platform_api).to receive(:get).with('bibs/test-nypl/1/is-research').and_return({"isResearch" => true})
-            expect(is_research?({'nyplSource' => 'test-nypl', 'id' => '1'})).to eq(true)
-        end
-
-        it "should return false if API response is false" do
-            expect($platform_api).to receive(:get).with('bibs/test-nypl/1/is-research').and_return({"isResearch" => false})
-            expect(is_research?({'nyplSource' => 'test-nypl', 'id' => '1'})).to eq(false)
-        end
-
-        it "should return false if API request receives an error" do
-            expect($platform_api).to receive(:get).with('bibs/test-nypl/1/is-research').and_raise(Exception.new)
-            expect(is_research?({'nyplSource' => 'test-nypl', 'id' => '1'})).to eq(false)
-        end
-    end
-
-    describe "#have_subject_headings_changed?" do
-        # TODO
-    end 
+  describe "#have_subject_headings_changed?" do
+    # TODO
+  end 
 end

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -1,0 +1,178 @@
+require 'spec_helper'
+
+describe "handler" do
+    describe "#init" do
+        before(:each) {
+            allow(AvroDecoder).to receive(:by_name).with("Bib")
+        }
+        it "should set initialized to true" do
+            expect(AvroDecoder).to receive(:by_name).with("Bib")
+            init
+            expect($initialized).to eq(true)
+        end
+    end
+
+    describe "#handle_event" do
+        it "should process all events passed in" do
+            test_records = [{"eventSource" => "aws:kinesis", :rec => 1}, {"eventSource" => "aws:kinesis", :rec => 2}]
+            allow(Parallel).to receive(:map).with(test_records, in_processes: 3).and_return([true, true])
+    
+            records_status = handle_event(event: {"Records" => test_records}, context: {})
+            expect(records_status).to eq([true, true])
+        end
+
+        it "should do nothing if no records are present in the event" do
+            test_records = []
+            records_status = handle_event(event: {"Records" => test_records}, context: {})
+            expect(records_status).to eq([])
+        end
+    end
+
+    describe "#process_record" do
+        before(:each) {
+            @record = {"id" => 1}
+        }
+
+        it "should invoke store_record if record is processable" do
+            allow(self).to receive(:parse_record).and_return(@record)
+            allow(self).to receive(:should_process?).with(@record).and_return(true)
+            allow(self).to receive(:store_record).with(@record).and_return(true)
+
+            result = process_record(@record)
+
+            expect(result).to eq(true)
+        end
+
+        it "should return SKIPPING STATUS if should_process? is false" do
+            allow(self).to receive(:parse_record).and_return(@record)
+            allow(self).to receive(:should_process?).with(@record).and_return(false)
+
+            result = process_record(@record)
+
+            expect(result).to eq([1, 'SKIPPING'])
+        end
+
+        it "should return ERROR if decoded_record is nill" do
+            allow(self).to receive(:parse_record).and_return(nil)
+
+            result = process_record(@record)
+
+            expect(result).to eq([nil, 'ERROR'])
+        end
+    end
+    
+    describe "#parse_record" do
+        before(:each) {
+            $avro_decoder = double()
+            allow($avro_decoder).to receive(:decode)
+        }
+
+        it "should return an object if avro decoding succeeds" do
+            valid_record = {
+                "kinesis" => {
+                    "data" => {"encoded" => {:id => 1, :title => "testing"}}
+                }
+            }
+
+            expect($avro_decoder).to receive(:decode).and_return(valid_record["kinesis"]["data"]["encoded"])
+
+            decoded_record = parse_record(valid_record)
+
+            expect(decoded_record[:id]).to eq(1)
+            expect(decoded_record[:title]).to eq("testing")
+        end
+
+        it "should raise an error if avro fails to decode a record" do
+            valid_record = {
+                "kinesis" => {
+                    "data" => {"encoded" => {:id => 1, :title => "testing"}}
+                }
+            }
+
+            expect($avro_decoder).to receive(:decode).and_raise(AvroError.new("testing"))
+
+            decoded_record = parse_record(valid_record)
+
+            expect(decoded_record).to eq(nil)
+        end
+
+        it "should raise an error if the document is malformed" do
+            invalid_record = {}
+            decoded_record = parse_record(invalid_record)
+            expect(decoded_record).to eq(nil)
+        end
+    end
+
+    describe "#store_record" do
+        before(:each) { allow(Net::HTTP).to receive(:post_form) }
+
+        it "should return success if SHEP API returns 200" do
+            resp = double("response", :code => '200', :body => JSON.dump({'message' => 'success'}))
+            expect(Net::HTTP).to receive(:post_form).and_return(resp)
+
+            output = store_record({'id' => 1, 'nypl-source' => 'nypl-test'})
+            expect(output).to eq([1, 'SUCCESS'])
+        end
+
+        it "should return error if SHEP API returns 400+" do
+            resp = double("response", :code => '403', :body => JSON.dump({'message' => 'error'}))
+            expect(Net::HTTP).to receive(:post_form).and_return(resp)
+
+            output = store_record({'id' => 1, 'nypl-source' => 'nypl-test'})
+            expect(output).to eq([1, 'ERROR'])
+        end
+    end
+
+    describe "#should_process?" do
+        before(:each) {
+            allow(self).to receive(:is_research?)
+            allow(self).to receive(:have_subject_headings_changed?)
+        }
+        
+        it "should return true if is_research and have_subject_headings_changed return true" do
+            expect(self).to receive(:is_research?).with('data').and_return(true)
+            expect(self).to receive(:have_subject_headings_changed?).with('data').and_return(true)
+
+            expect(should_process?('data')).to eq(true)
+        end
+        
+        it "should return false if is_research is false and not call have_subject_headings_changed?" do
+            expect(self).to receive(:is_research?).with('data').and_return(false)
+            expect(self).to_not receive(:have_subject_headings_changed?).with('data')
+
+            expect(should_process?('data')).to eq(false)
+        end
+        
+        it "should return false if have_subject_headings_changed returns false" do
+            expect(self).to receive(:is_research?).with('data').and_return(true)
+            expect(self).to receive(:have_subject_headings_changed?).with('data').and_return(false)
+
+            expect(should_process?('data')).to eq(false)
+        end
+    end
+
+    describe "#is_research?" do
+        before(:each) {
+            allow($platform_api).to receive(:get)
+        }
+
+        it "should return true if API response is true" do
+            expect($platform_api).to receive(:get).with('bibs/test-nypl/1/is-research').and_return({"isResearch" => true})
+            expect(is_research?({'nyplSource' => 'test-nypl', 'id' => '1'})).to eq(true)
+        end
+
+        it "should return false if API response is false" do
+            expect($platform_api).to receive(:get).with('bibs/test-nypl/1/is-research').and_return({"isResearch" => false})
+            expect(is_research?({'nyplSource' => 'test-nypl', 'id' => '1'})).to eq(false)
+        end
+
+        it "should return false if API request receives an error" do
+            expect($platform_api).to receive(:get).with('bibs/test-nypl/1/is-research').and_raise(Exception.new)
+            expect(is_research?({'nyplSource' => 'test-nypl', 'id' => '1'})).to eq(false)
+        end
+    end
+
+    describe "#have_subject_headings_changed?" do
+        # TODO
+    end 
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'json'
 require 'nypl_log_formatter'
 require 'base64'
 
+require_relative '../app'
 require_relative '../lib/avro_decoder'
 require_relative '../lib/bib_data_manager'
 
@@ -12,6 +13,7 @@ ENV['NYPL_OAUTH_ID'] = Base64.strict_encode64 'fake-client'
 ENV['NYPL_OAUTH_SECRET'] = Base64.strict_encode64 'fake-secret'
 ENV['NYPL_OAUTH_URL'] = 'https://isso.example.com/'
 ENV['NYPL_CORE_S3_BASE_URL'] = 'https://example.com/'
+ENV['SHEP_API_BIBS_ENDPOINT'] = 'https://example/shep_api/bib'
 
 def minimal_bib_data_manager(snake_case: true)
   bare_bib_data = {


### PR DESCRIPTION
This converts the main handler method for the function to a method that invokes a multi-processed pool of jobs which work on processing SHEP updates int parallel. This is a simple conversion where all the logic within each process represents the processing for a single record with the outcome being returned from the method invoked.

Hypothetically this will realize a large performance gain in the Poster as Neo4j claims to be able to handle parallel requests rather easily. But this has not been proven and we also have to make sure that the lambda is appropriately provisioned to take advantage of this.

This also adds some unit tests for the methods in the `app.rb` module