### PR TITLE
SCC-2554 Mishandled exception

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -106,7 +106,7 @@ def have_subject_headings_changed? data
   # discovery id can come from BibDataManager
   begin
     bib_data = SHEP::BibDataManager.new(data)
-  rescue BibDataManagerError => e
+  rescue SHEP::BibDataManagerError => e
     $logger.error "Unable to process record due to: #{e.message}"
     return false
   end

--- a/lib/bib_data_manager.rb
+++ b/lib/bib_data_manager.rb
@@ -3,6 +3,8 @@ require_relative 'subject_component_data_manager'
 require_relative 'subfield_data_manager'
 
 class SHEP
+  class BibDataManagerError < StandardError; end
+
   class BibDataManager
     attr_reader :institution, :bib_id, :heading_data_mgrs, :discovery_id
 

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -173,6 +173,10 @@ describe "handler" do
   end
 
   describe "#have_subject_headings_changed?" do
-    # TODO
+    it 'should return false with title-less bib data' do
+      bib_data = minimal_bib_data.reject { |k,_| k == 'title' }
+
+      expect(have_subject_headings_changed? bib_data).to eq(false)
+    end
   end 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,11 +15,11 @@ ENV['NYPL_OAUTH_URL'] = 'https://isso.example.com/'
 ENV['NYPL_CORE_S3_BASE_URL'] = 'https://example.com/'
 ENV['SHEP_API_BIBS_ENDPOINT'] = 'https://example/shep_api/bib'
 
-def minimal_bib_data_manager(snake_case: true)
+def minimal_bib_data(snake_case: true)
   bare_bib_data = {
     'id' => '123456',
     'title' => 'Minimal bib',
-    'lang' => JSON.dump({ 'code' => 'eng' }),
+    'lang' => JSON.dump({ 'code' => 'eng' })
   }
 
   var_fields_key = snake_case ? 'var_fields' : 'varFields'
@@ -27,6 +27,9 @@ def minimal_bib_data_manager(snake_case: true)
 
   bare_bib_data[var_fields_key] = JSON.dump({})
   bare_bib_data[nypl_source_key] = 'sierra_nypl'
+  bare_bib_data
+end
 
-  SHEP::BibDataManager.new(bare_bib_data)
+def minimal_bib_data_manager(snake_case: true)
+  SHEP::BibDataManager.new(minimal_bib_data(snake_case: snake_case))
 end


### PR DESCRIPTION
Please see https://jira.nypl.org/browse/SCC-2554 for screenshot of unhandled exception.

Exception was being rescued as BibDataManagerError, where should have been SHEP::BibDataManagerError. Added a test to demonstrate that, and added the namespace.