### PR TITLE
NOREF Add Parallel Processing Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ deploy:
   - NYPL_OAUTH_SECRET=AQECAHjqALewp8JBJNxIQvR4oY795dyG7INaGR1glMsTEgetggAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAzvLVLGEyP0EuIQC9YCARCAQ1AKv2geABsSFPvtI1JWX6YMbL348GLXhgK/dCrYs6aMQrufTjSlUi2ytOvbJpcSkPqDxHyfpjnfzBI7lGSVKP7D3mA=
   - NYPL_CORE_S3_BASE_URL=https://s3.amazonaws.com/nypl-core-objects-mapping-production/
   - LOG_LEVEL=debug
+  - PARALLEL_PROCESSES='2'
   access_key_id: "$AWS_ACCESS_KEY_ID_DEV"
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_DEV"
   on:
@@ -54,6 +55,7 @@ deploy:
   - NYPL_OAUTH_SECRET=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAwDTxUAqKkiCrdL90MCARCAQ8vxU5R+MEGRpWFPhktni6yfDNoecmxWlerXkaWk+ZUaPKdUlkTI1kDITaWnwf9VvR4N9XwGgKMLfWgM+sW72715eqc=
   - NYPL_CORE_S3_BASE_URL=https://s3.amazonaws.com/nypl-core-objects-mapping-production/
   - LOG_LEVEL=debug
+  - PARALLEL_PROCESSES='2'
   access_key_id: "$AWS_ACCESS_KEY_ID_QA"
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"
   on:

--- a/app.rb
+++ b/app.rb
@@ -28,7 +28,7 @@ def handle_event(event:, context:)
     end
 
   # Process records in parallel
-  record_results = Parallel.map(records_to_process, in_processes: 3) { |record| process_record(record) }
+  record_results = Parallel.map(records_to_process, in_processes: ENV['PARALLEL_PROCESSES'].to_i) { |record| process_record(record) }
 end
 
 def process_record record

--- a/sam.dev.yml
+++ b/sam.dev.yml
@@ -31,3 +31,4 @@ Resources:
           NYPL_OAUTH_SECRET: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAzqpSpOyAs6z7xuhIYCARCAQxQmBeJEIuw09MFA+nmoqMfE7ZvqsfLUCsOlDApqRhiEM3M3pfWOaoK7kTKR+37sgrYqSkZTZuMWGzzFTXa2z0QKB7c=
           NYPL_CORE_S3_BASE_URL: https://s3.amazonaws.com/nypl-core-objects-mapping-production/
           SHEP_API_BIBS_ENDPOINT: http://shep-api-new-development.us-east-1.elasticbeanstalk.com/api/v0.1/bibs/
+	  PARALLEL_PROCESSES: '2'

--- a/sam.dev.yml
+++ b/sam.dev.yml
@@ -31,4 +31,4 @@ Resources:
           NYPL_OAUTH_SECRET: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAzqpSpOyAs6z7xuhIYCARCAQxQmBeJEIuw09MFA+nmoqMfE7ZvqsfLUCsOlDApqRhiEM3M3pfWOaoK7kTKR+37sgrYqSkZTZuMWGzzFTXa2z0QKB7c=
           NYPL_CORE_S3_BASE_URL: https://s3.amazonaws.com/nypl-core-objects-mapping-production/
           SHEP_API_BIBS_ENDPOINT: http://shep-api-new-development.us-east-1.elasticbeanstalk.com/api/v0.1/bibs/
-	  PARALLEL_PROCESSES: '2'
+          PARALLEL_PROCESSES: '2'

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -29,3 +29,4 @@ Resources:
           NYPL_OAUTH_SECRET: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAzqpSpOyAs6z7xuhIYCARCAQxQmBeJEIuw09MFA+nmoqMfE7ZvqsfLUCsOlDApqRhiEM3M3pfWOaoK7kTKR+37sgrYqSkZTZuMWGzzFTXa2z0QKB7c=
           NYPL_CORE_S3_BASE_URL: https://s3.amazonaws.com/nypl-core-objects-mapping-production/
           SHEP_API_BIBS_ENDPOINT: http://docker.for.mac.localhost:3000/api/v0.1/bibs/
+	  PARALLEL_PROCESSES: '2'

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -29,4 +29,4 @@ Resources:
           NYPL_OAUTH_SECRET: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAzqpSpOyAs6z7xuhIYCARCAQxQmBeJEIuw09MFA+nmoqMfE7ZvqsfLUCsOlDApqRhiEM3M3pfWOaoK7kTKR+37sgrYqSkZTZuMWGzzFTXa2z0QKB7c=
           NYPL_CORE_S3_BASE_URL: https://s3.amazonaws.com/nypl-core-objects-mapping-production/
           SHEP_API_BIBS_ENDPOINT: http://docker.for.mac.localhost:3000/api/v0.1/bibs/
-	  PARALLEL_PROCESSES: '2'
+          PARALLEL_PROCESSES: '2'

--- a/sam.production.yml
+++ b/sam.production.yml
@@ -32,4 +32,4 @@ Resources:
           NYPL_OAUTH_SECRET: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAzqpSpOyAs6z7xuhIYCARCAQxQmBeJEIuw09MFA+nmoqMfE7ZvqsfLUCsOlDApqRhiEM3M3pfWOaoK7kTKR+37sgrYqSkZTZuMWGzzFTXa2z0QKB7c=
           NYPL_CORE_S3_BASE_URL: https://s3.amazonaws.com/nypl-core-objects-mapping-production/
           SHEP_API_BIBS_ENDPOINT: http://subjectheadingexplorerpoc-production.us-east-1.elasticbeanstalk.com/api/v0.1/bibs/
-	  PARALLEL_PROCESSES: '2'
+          PARALLEL_PROCESSES: '2'

--- a/sam.production.yml
+++ b/sam.production.yml
@@ -32,3 +32,4 @@ Resources:
           NYPL_OAUTH_SECRET: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAzqpSpOyAs6z7xuhIYCARCAQxQmBeJEIuw09MFA+nmoqMfE7ZvqsfLUCsOlDApqRhiEM3M3pfWOaoK7kTKR+37sgrYqSkZTZuMWGzzFTXa2z0QKB7c=
           NYPL_CORE_S3_BASE_URL: https://s3.amazonaws.com/nypl-core-objects-mapping-production/
           SHEP_API_BIBS_ENDPOINT: http://subjectheadingexplorerpoc-production.us-east-1.elasticbeanstalk.com/api/v0.1/bibs/
+	  PARALLEL_PROCESSES: '2'

--- a/sam.qa.yml
+++ b/sam.qa.yml
@@ -32,4 +32,4 @@ Resources:
           NYPL_OAUTH_SECRET: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAzqpSpOyAs6z7xuhIYCARCAQxQmBeJEIuw09MFA+nmoqMfE7ZvqsfLUCsOlDApqRhiEM3M3pfWOaoK7kTKR+37sgrYqSkZTZuMWGzzFTXa2z0QKB7c=
           NYPL_CORE_S3_BASE_URL: https://s3.amazonaws.com/nypl-core-objects-mapping-production/
           SHEP_API_BIBS_ENDPOINT: https://subjectheadingexplorerpoc-qa-2.pchxmxsxky.us-east-1.elasticbeanstalk.com/api/v0.1/bibs/
-	  PARALLEL_PROCESSES: '2'
+          PARALLEL_PROCESSES: '2'

--- a/sam.qa.yml
+++ b/sam.qa.yml
@@ -32,3 +32,4 @@ Resources:
           NYPL_OAUTH_SECRET: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAzqpSpOyAs6z7xuhIYCARCAQxQmBeJEIuw09MFA+nmoqMfE7ZvqsfLUCsOlDApqRhiEM3M3pfWOaoK7kTKR+37sgrYqSkZTZuMWGzzFTXa2z0QKB7c=
           NYPL_CORE_S3_BASE_URL: https://s3.amazonaws.com/nypl-core-objects-mapping-production/
           SHEP_API_BIBS_ENDPOINT: https://subjectheadingexplorerpoc-qa-2.pchxmxsxky.us-east-1.elasticbeanstalk.com/api/v0.1/bibs/
+	  PARALLEL_PROCESSES: '2'

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -15,7 +15,7 @@ describe "handler" do
   describe "#handle_event" do
     it "should process all events passed in" do
       test_records = [{"eventSource" => "aws:kinesis", :rec => 1}, {"eventSource" => "aws:kinesis", :rec => 2}]
-      allow(Parallel).to receive(:map).with(test_records, in_processes: 3).and_return([true, true])
+      allow(Parallel).to receive(:map).with(test_records, in_processes: 2).and_return([true, true])
   
       records_status = handle_event(event: {"Records" => test_records}, context: {})
       expect(records_status).to eq([true, true])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ ENV['NYPL_OAUTH_SECRET'] = Base64.strict_encode64 'fake-secret'
 ENV['NYPL_OAUTH_URL'] = 'https://isso.example.com/'
 ENV['NYPL_CORE_S3_BASE_URL'] = 'https://example.com/'
 ENV['SHEP_API_BIBS_ENDPOINT'] = 'https://example/shep_api/bib'
+ENV['PARALLEL_PROCESSES'] = '2'
 
 def minimal_bib_data(snake_case: true)
   bare_bib_data = {


### PR DESCRIPTION
This makes the number of parellel calls to the SHEP API configurable as an environment variable. The impetus for this is that the current setting is potentially too high and needs to be lowered. This both sets the process to 2 to do so and makes it possible to adjust the value in the AWS Lambda console without further PRs.