### PR TITLE
SCC-2916:   use 911$a field to determine whether Bib is Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Subject Heading Poster
-The `SubjectHeadingPoster` is a Lambda listening to the `BibStream` to post bib data to the [Subject Heading (SHEP) API](https://github.com/NYPL/subject-headings-explorer-poc/tree/shep-api). It only posts Bib records that it identifies as Research bibs. It does that by first looking for a 911 var field, subfield a ('RL' in the content field means the Bib is Research); if there's no 911|a field it falls back to the `isResearchLayer` which is a Lambda Layer deployed on AWS. The code for the Layer lives in the [`is-research-service`](https://github.com/NYPL/is-research-service) repo.
+The `SubjectHeadingPoster` is a Lambda listening to the `BibStream` to post bib data to the [Subject Heading (SHEP) API](https://github.com/NYPL/subject-headings-explorer-poc/tree/shep-api). It only posts Bib records that it identifies as Research bibs. It does that by first looking for a 911 var field, subfield a ('RL' in the content field means the Bib is Research); if there's no 911$a field it falls back to the `isResearchLayer` which is a Lambda Layer deployed on AWS. The code for the Layer lives in the [`is-research-service`](https://github.com/NYPL/is-research-service) repo.
 
 ## Setup
 This services use the Ruby2.5 runtime.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Subject Heading Poster
-The `SubjectHeadingPoster` is a Lambda listening to the `BibStream` to post bib data to the [Subject Heading (SHEP) API](https://github.com/NYPL/subject-headings-explorer-poc/tree/shep-api). It only posts Bib records that it identifies as Research bibs. It does that by first looking for a 911 var field, subfield a ('RL' in the content field means the Bib is Research); if there's no 911$a field it falls back to the `isResearchLayer` which is a Lambda Layer deployed on AWS. The code for the Layer lives in the [`is-research-service`](https://github.com/NYPL/is-research-service) repo.
+The `SubjectHeadingPoster` is a Lambda listening to the `BibStream` to post bib data to the [Subject Heading (SHEP) API](https://github.com/NYPL/subject-headings-explorer-poc/tree/shep-api). It only posts Bib records that it identifies as Research bibs. It does that by first looking for a 911 var field, subfield a ('RL' in the content field means the Bib is Research); if there's no 911|a field it falls back to the `isResearchLayer` which is a Lambda Layer deployed on AWS. The code for the Layer lives in the [`is-research-service`](https://github.com/NYPL/is-research-service) repo.
 
 ## Setup
 This services use the Ruby2.5 runtime.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Subject Heading Poster
-The `SubjectHeadingPoster` is a Lambda listening to the `BibStream` to post bib data to the [Subject Heading (SHEP) API](https://github.com/NYPL/subject-headings-explorer-poc/tree/shep-api). It pulls in the `isResearchLayer` which is a Lambda Layer deployed on AWS. The code for the Layer lives in the [`is-research-service`](https://github.com/NYPL/is-research-service) repo.
+The `SubjectHeadingPoster` is a Lambda listening to the `BibStream` to post bib data to the [Subject Heading (SHEP) API](https://github.com/NYPL/subject-headings-explorer-poc/tree/shep-api). It only posts Bib records that it identifies as Research bibs. It does that by first looking for a 911 var field, subfield a ('RL' in the content field means the Bib is Research); if there's no 911$a field it falls back to the `isResearchLayer` which is a Lambda Layer deployed on AWS. The code for the Layer lives in the [`is-research-service`](https://github.com/NYPL/is-research-service) repo.
 
 ## Setup
 This services use the Ruby2.5 runtime.

--- a/app.rb
+++ b/app.rb
@@ -99,7 +99,7 @@ def is_research? data
     return subfield_a['content'] == 'RL' if subfield_a
   end
 
-  # Only get here if no 911|a field set (once all records have a 911|a the rest of this method can be deleted)
+  # Only get here if no 911$a field set (once all records have a 911$a the rest of this method can be deleted)
   nypl_source = data['nyplSource']
   bib_id = data['id']
 

--- a/app.rb
+++ b/app.rb
@@ -92,13 +92,14 @@ def is_research? data
   rescue JSON::ParserError
   end
 
-  var_fields.select { |vf| vf['marcTag'] == '911' }.each do |vf_911|
-    subfield_a = vf_911['subfields'].find { |sf| sf['tag'] == 'a' }
+  marc911_var_fields = var_fields.select { |vf| vf['marcTag'] == '911' }
+  marc911_var_fields.each do |m911_vf|
+    subfield_a = m911_vf['subfields'].find { |sf| sf['tag'] == 'a' }
 
     return subfield_a['content'] == 'RL' if subfield_a
   end
 
-  # Only get here if there was no 911$a field set
+  # Only get here if no 911$a field set (once all records have a 911$a the rest of this method can be deleted)
   nypl_source = data['nyplSource']
   bib_id = data['id']
 

--- a/app.rb
+++ b/app.rb
@@ -99,7 +99,7 @@ def is_research? data
     return subfield_a['content'] == 'RL' if subfield_a
   end
 
-  # Only get here if no 911$a field set (once all records have a 911$a the rest of this method can be deleted)
+  # Only get here if no 911|a field set (once all records have a 911|a the rest of this method can be deleted)
   nypl_source = data['nyplSource']
   bib_id = data['id']
 

--- a/app.rb
+++ b/app.rb
@@ -93,14 +93,12 @@ def is_research? data
   end
 
   if var_fields
-    field_911 = var_fields.find { |vf| vf['marcTag'] == '911' }
+    field_911 = var_fields.find { |vf| vf['marcTag'] == '911' and vf['subfields'].find { |sf| sf['tag'] == 'a' } }
 
     if field_911
       subfield_a = field_911['subfields'].find { |sf| sf['tag'] == 'a' }
 
-      if subfield_a
-        return subfield_a['content'] == 'RL'
-      end
+      return subfield_a['content'] == 'RL'
     end
   end
 

--- a/app.rb
+++ b/app.rb
@@ -86,19 +86,17 @@ def store_record decoded
 end
 
 def is_research? data
-  var_fields_json = data['varFields'] || ''
+  var_fields_json = data['varFields'] || '[]'
   begin 
     var_fields = JSON.parse(var_fields_json)
   rescue JSON::ParserError
   end
 
-  if var_fields
-    field_911 = var_fields.find { |vf| vf['marcTag'] == '911' and vf['subfields'].find { |sf| sf['tag'] == 'a' } }
+  var_fields.each do |vf|
+    if vf['marcTag'] == '911'
+      subfield_a = vf['subfields'].find { |sf| sf['tag'] == 'a' }
 
-    if field_911
-      subfield_a = field_911['subfields'].find { |sf| sf['tag'] == 'a' }
-
-      return subfield_a['content'] == 'RL'
+      return subfield_a['content'] == 'RL' if subfield_a
     end
   end
 

--- a/app.rb
+++ b/app.rb
@@ -86,6 +86,25 @@ def store_record decoded
 end
 
 def is_research? data
+  var_fields_json = data['varFields'] || ''
+  begin 
+    var_fields = JSON.parse(var_fields_json)
+  rescue JSON::ParserError
+  end
+
+  if var_fields
+    field_911 = var_fields.find { |vf| vf['marcTag'] == '911' }
+
+    if field_911
+      subfield_a = field_911['subfields'].find { |sf| sf['tag'] == 'a' }
+
+      if subfield_a
+        return subfield_a['content'] == 'RL'
+      end
+    end
+  end
+
+  # Only get here if there was no 911$a field set
   nypl_source = data['nyplSource']
   bib_id = data['id']
 
@@ -97,7 +116,7 @@ def is_research? data
   end
   
   unless research_status["isResearch"]
-    $logger.debug "Circulating bib #{bib_id}, will not process"
+    $logger.debug "Bib #{bib_id} determined as Circulating by is_research service, will not process"
     return false
   end
 

--- a/app.rb
+++ b/app.rb
@@ -92,12 +92,10 @@ def is_research? data
   rescue JSON::ParserError
   end
 
-  var_fields.each do |vf|
-    if vf['marcTag'] == '911'
-      subfield_a = vf['subfields'].find { |sf| sf['tag'] == 'a' }
+  var_fields.select { |vf| vf['marcTag'] == '911' }.each do |vf_911|
+    subfield_a = vf_911['subfields'].find { |sf| sf['tag'] == 'a' }
 
-      return subfield_a['content'] == 'RL' if subfield_a
-    end
+    return subfield_a['content'] == 'RL' if subfield_a
   end
 
   # Only get here if there was no 911$a field set

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,17 @@
+**What's this do?**
+[Description of what this PR does goes here]
+
+**Why are we doing this? (w/ JIRA link if applicable)**
+[Quick blurb about why the code is needed and Jira link goes here / Do these changes meet the business requirements of the story?]
+
+**How should this be tested? / Do these changes have associated tests?**
+[Description of any tests that need to be performed once merged goes here]
+
+**Dependencies for merging? Releasing to production?**
+[Description of any watchouts, dependencies, or issues we should be aware of goes here]
+
+**Has the application documentation been updated for these changes?**
+
+**Did someone actually run this code to verify it works?**
+
+

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -213,6 +213,21 @@ describe "handler" do
       expect(is_research?({'varFields' => json_varfields})).to eq(false)
     end
 
+    it "should ignore 911 without an 'a' subfield, processing a later one with an 'a' subfield" do
+      json_varfields = JSON.dump([
+        {
+          'marcTag' => '911',
+          'subfields' => [{ 'content' => 'BL', 'tag' => 'b' }]
+        },
+        {
+          'marcTag' => '911',
+          'subfields' => [{ 'content' => 'RL', 'tag' => 'a' }]
+        }
+      ])
+
+      expect(is_research?({'varFields' => json_varfields})).to eq(true)
+    end
+
     it "should return true if API response is true" do
       expect($platform_api).to receive(:get).with('bibs/test-nypl/1/is-research').and_return({"isResearch" => true})
       expect(is_research?({'nyplSource' => 'test-nypl', 'id' => '1'})).to eq(true)

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -171,7 +171,7 @@ describe "handler" do
       expect(is_research?({'varFields' => json_varfields})).to eq(false)
     end
 
-    # It's only the 911$a Marc field that we know is used for this. A 911 field with anything else could be 
+    # It's only the 911|a Marc field that we know is used for this. A 911 field with anything else could be 
     #   for a different purpose so it tells us nothing about the research status of this Bib
     it "should fallback to API if there is a 911 field with subfield tag other than a" do
       json_varfields = JSON.dump([{
@@ -183,7 +183,7 @@ describe "handler" do
       expect(is_research?({'id' => '1', 'nyplSource' => 'test-nypl', 'varFields' => json_varfields})).to eq(true)
     end
 
-    it "should take the first 911$a field if there are multiples (RL first test)" do
+    it "should take the first 911|a field if there are multiples (RL first test)" do
       json_varfields = JSON.dump([
         {
           'marcTag' => '911',
@@ -198,7 +198,7 @@ describe "handler" do
       expect(is_research?({'varFields' => json_varfields})).to eq(true)
     end
 
-    it "should take the first 911$a field if there are multiples (BL first test)" do
+    it "should take the first 911|a field if there are multiples (BL first test)" do
       json_varfields = JSON.dump([
         {
           'marcTag' => '911',

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -171,7 +171,7 @@ describe "handler" do
       expect(is_research?({'varFields' => json_varfields})).to eq(false)
     end
 
-    # It's only the 911|a Marc field that we know is used for this. A 911 field with anything else could be 
+    # It's only the 911$a Marc field that we know is used for this. A 911 field with anything else could be 
     #   for a different purpose so it tells us nothing about the research status of this Bib
     it "should fallback to API if there is a 911 field with subfield tag other than a" do
       json_varfields = JSON.dump([{
@@ -183,7 +183,7 @@ describe "handler" do
       expect(is_research?({'id' => '1', 'nyplSource' => 'test-nypl', 'varFields' => json_varfields})).to eq(true)
     end
 
-    it "should take the first 911|a field if there are multiples (RL first test)" do
+    it "should take the first 911$a field if there are multiples (RL first test)" do
       json_varfields = JSON.dump([
         {
           'marcTag' => '911',
@@ -198,7 +198,7 @@ describe "handler" do
       expect(is_research?({'varFields' => json_varfields})).to eq(true)
     end
 
-    it "should take the first 911|a field if there are multiples (BL first test)" do
+    it "should take the first 911$a field if there are multiples (BL first test)" do
       json_varfields = JSON.dump([
         {
           'marcTag' => '911',

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -144,6 +144,75 @@ describe "handler" do
       allow($platform_api).to receive(:get)
     }
 
+    it "should return true if there is a 911 field with subfield tag of a and a value of RL" do
+      json_varfields = JSON.dump([{
+        'marcTag' => '911',
+        'subfields' => [{ 'content' => 'RL', 'tag' => 'a' }]
+      }])
+
+      expect(is_research?({'varFields' => json_varfields})).to eq(true)
+    end
+
+    it "should return false if there is a 911 field with subfield tag of a and a value of BL" do
+      json_varfields = JSON.dump([{
+        'marcTag' => '911',
+        'subfields' => [{ 'content' => 'BL', 'tag' => 'a' }]
+      }])
+
+      expect(is_research?({'varFields' => json_varfields})).to eq(false)
+    end
+
+    it "should return false if there is a 911 field with subfield tag of a and a value of anything else" do
+      json_varfields = JSON.dump([{
+        'marcTag' => '911',
+        'subfields' => [{ 'content' => 'RLOTF', 'tag' => 'a' }]
+      }])
+
+      expect(is_research?({'varFields' => json_varfields})).to eq(false)
+    end
+
+    # It's only the 911$a Marc field that we know is used for this. A 911 field with anything else could be 
+    #   for a different purpose so it tells us nothing about the research status of this Bib
+    it "should fallback to API if there is a 911 field with subfield tag other than a" do
+      json_varfields = JSON.dump([{
+        'marcTag' => '911',
+        'subfields' => [{ 'content' => 'RL', 'tag' => 'z' }]
+      }])
+
+      expect($platform_api).to receive(:get).with('bibs/test-nypl/1/is-research').and_return({"isResearch" => true})
+      expect(is_research?({'id' => '1', 'nyplSource' => 'test-nypl', 'varFields' => json_varfields})).to eq(true)
+    end
+
+    it "should take the first 911$a field if there are multiples (RL first test)" do
+      json_varfields = JSON.dump([
+        {
+          'marcTag' => '911',
+          'subfields' => [{ 'content' => 'RL', 'tag' => 'a' }]
+        },
+        {
+          'marcTag' => '911',
+          'subfields' => [{ 'content' => 'BL', 'tag' => 'a' }]
+        }
+      ])
+
+      expect(is_research?({'varFields' => json_varfields})).to eq(true)
+    end
+
+    it "should take the first 911$a field if there are multiples (BL first test)" do
+      json_varfields = JSON.dump([
+        {
+          'marcTag' => '911',
+          'subfields' => [{ 'content' => 'BL', 'tag' => 'a' }]
+        },
+        {
+          'marcTag' => '911',
+          'subfields' => [{ 'content' => 'RL', 'tag' => 'a' }]
+        }
+      ])
+
+      expect(is_research?({'varFields' => json_varfields})).to eq(false)
+    end
+
     it "should return true if API response is true" do
       expect($platform_api).to receive(:get).with('bibs/test-nypl/1/is-research').and_return({"isResearch" => true})
       expect(is_research?({'nyplSource' => 'test-nypl', 'id' => '1'})).to eq(true)
@@ -158,5 +227,7 @@ describe "handler" do
       expect($platform_api).to receive(:get).with('bibs/test-nypl/1/is-research').and_raise(Exception.new)
       expect(is_research?({'nyplSource' => 'test-nypl', 'id' => '1'})).to eq(false)
     end
+
+
   end
 end


### PR DESCRIPTION
**What's this do?**
Adds checks in the Bib record for the Marc field 911, subfield a, and then uses that to determine whether the Bib is Research or not. If there's no 911$a field available it falls back to using the is_research service.

**Why are we doing this? (w/ JIRA link if applicable)**
Once 911$a fields can be relied on to appear in all records we will eventually deprecate the is_research service, so this change prepares for that change. Additionally, hitting is_research puts load on the Item service, so taking advantage _now_ of the new fields when available should significantly help the overall health and performance of the LSP systems.

**How should this be tested? / Do these changes have associated tests?**
There are unit tests. It should also be tested in the QA (I have not created new sample events with the 911 field in, but that should be done).

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
READMEN.md and comments updated.

**Did someone actually run this code to verify it works?**
Only in tests.
