### PR TITLE
Turns out we should use 910$a, not 911$a

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Subject Heading Poster
-The `SubjectHeadingPoster` is a Lambda listening to the `BibStream` to post bib data to the [Subject Heading (SHEP) API](https://github.com/NYPL/subject-headings-explorer-poc/tree/shep-api). It only posts Bib records that it identifies as Research bibs. It does that by first looking for a 911 var field, subfield a ('RL' in the content field means the Bib is Research); if there's no 911$a field it falls back to the `isResearchLayer` which is a Lambda Layer deployed on AWS. The code for the Layer lives in the [`is-research-service`](https://github.com/NYPL/is-research-service) repo.
+The `SubjectHeadingPoster` is a Lambda listening to the `BibStream` to post bib data to the [Subject Heading (SHEP) API](https://github.com/NYPL/subject-headings-explorer-poc/tree/shep-api). It only posts Bib records that it identifies as Research bibs. It does that by first looking for a 910 var field, subfield a ('RL' in the content field means the Bib is Research); if there's no 910|a field it falls back to the `isResearchLayer` which is a Lambda Layer deployed on AWS. The code for the Layer lives in the [`is-research-service`](https://github.com/NYPL/is-research-service) repo.
 
 ## Setup
 This services use the Ruby2.5 runtime.

--- a/app.rb
+++ b/app.rb
@@ -92,14 +92,14 @@ def is_research? data
   rescue JSON::ParserError
   end
 
-  marc911_var_fields = var_fields.select { |vf| vf['marcTag'] == '911' }
-  marc911_var_fields.each do |m911_vf|
-    subfield_a = m911_vf['subfields'].find { |sf| sf['tag'] == 'a' }
+  marc910_var_fields = var_fields.select { |vf| vf['marcTag'] == '910' }
+  marc910_var_fields.each do |m910_vf|
+    subfield_a = m910_vf['subfields'].find { |sf| sf['tag'] == 'a' }
 
     return subfield_a['content'] == 'RL' if subfield_a
   end
 
-  # Only get here if no 911$a field set (once all records have a 911$a the rest of this method can be deleted)
+  # Only get here if no 910|a field set (once all records have a 910|a the rest of this method can be deleted)
   nypl_source = data['nyplSource']
   bib_id = data['id']
 

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -144,38 +144,38 @@ describe "handler" do
       allow($platform_api).to receive(:get)
     }
 
-    it "should return true if there is a 911 field with subfield tag of a and a value of RL" do
+    it "should return true if there is a 910 field with subfield tag of a and a value of RL" do
       json_varfields = JSON.dump([{
-        'marcTag' => '911',
+        'marcTag' => '910',
         'subfields' => [{ 'content' => 'RL', 'tag' => 'a' }]
       }])
 
       expect(is_research?({'varFields' => json_varfields})).to eq(true)
     end
 
-    it "should return false if there is a 911 field with subfield tag of a and a value of BL" do
+    it "should return false if there is a 910 field with subfield tag of a and a value of BL" do
       json_varfields = JSON.dump([{
-        'marcTag' => '911',
+        'marcTag' => '910',
         'subfields' => [{ 'content' => 'BL', 'tag' => 'a' }]
       }])
 
       expect(is_research?({'varFields' => json_varfields})).to eq(false)
     end
 
-    it "should return false if there is a 911 field with subfield tag of a and a value of anything else" do
+    it "should return false if there is a 910 field with subfield tag of a and a value of anything else" do
       json_varfields = JSON.dump([{
-        'marcTag' => '911',
+        'marcTag' => '910',
         'subfields' => [{ 'content' => 'RLOTF', 'tag' => 'a' }]
       }])
 
       expect(is_research?({'varFields' => json_varfields})).to eq(false)
     end
 
-    # It's only the 911$a Marc field that we know is used for this. A 911 field with anything else could be 
+    # It's only the 910|a Marc field that we know is used for this. A 910 field with anything else could be 
     #   for a different purpose so it tells us nothing about the research status of this Bib
-    it "should fallback to API if there is a 911 field with subfield tag other than a" do
+    it "should fallback to API if there is a 910 field with subfield tag other than a" do
       json_varfields = JSON.dump([{
-        'marcTag' => '911',
+        'marcTag' => '910',
         'subfields' => [{ 'content' => 'RL', 'tag' => 'z' }]
       }])
 
@@ -183,14 +183,14 @@ describe "handler" do
       expect(is_research?({'id' => '1', 'nyplSource' => 'test-nypl', 'varFields' => json_varfields})).to eq(true)
     end
 
-    it "should take the first 911$a field if there are multiples (RL first test)" do
+    it "should take the first 910|a field if there are multiples (RL first test)" do
       json_varfields = JSON.dump([
         {
-          'marcTag' => '911',
+          'marcTag' => '910',
           'subfields' => [{ 'content' => 'RL', 'tag' => 'a' }]
         },
         {
-          'marcTag' => '911',
+          'marcTag' => '910',
           'subfields' => [{ 'content' => 'BL', 'tag' => 'a' }]
         }
       ])
@@ -198,14 +198,14 @@ describe "handler" do
       expect(is_research?({'varFields' => json_varfields})).to eq(true)
     end
 
-    it "should take the first 911$a field if there are multiples (BL first test)" do
+    it "should take the first 910|a field if there are multiples (BL first test)" do
       json_varfields = JSON.dump([
         {
-          'marcTag' => '911',
+          'marcTag' => '910',
           'subfields' => [{ 'content' => 'BL', 'tag' => 'a' }]
         },
         {
-          'marcTag' => '911',
+          'marcTag' => '910',
           'subfields' => [{ 'content' => 'RL', 'tag' => 'a' }]
         }
       ])
@@ -213,14 +213,14 @@ describe "handler" do
       expect(is_research?({'varFields' => json_varfields})).to eq(false)
     end
 
-    it "should ignore 911 without an 'a' subfield, processing a later one with an 'a' subfield" do
+    it "should ignore 910 without an 'a' subfield, processing a later one with an 'a' subfield" do
       json_varfields = JSON.dump([
         {
-          'marcTag' => '911',
+          'marcTag' => '910',
           'subfields' => [{ 'content' => 'BL', 'tag' => 'b' }]
         },
         {
-          'marcTag' => '911',
+          'marcTag' => '910',
           'subfields' => [{ 'content' => 'RL', 'tag' => 'a' }]
         }
       ])


### PR DESCRIPTION
**What's this do?**
Renames 911 field to 910 field

**Why are we doing this? (w/ JIRA link if applicable)**
Turns out 911 wasn't suitable so BookOps suggested 910 instead

**How should this be tested? / Do these changes have associated tests?**
Same tests as before apply

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
Yes

**Did someone actually run this code to verify it works?**
In tests. Should be tested on QA

