### PR TITLE
SCC-2916: Removed errenoeous JSON encoding

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -86,11 +86,7 @@ def store_record decoded
 end
 
 def is_research? data
-  var_fields_json = data['varFields'] || '[]'
-  begin 
-    var_fields = JSON.parse(var_fields_json)
-  rescue JSON::ParserError
-  end
+  var_fields = data['varFields'] || []
 
   marc910_var_fields = var_fields.select { |vf| vf['marcTag'] == '910' }
   marc910_var_fields.each do |m910_vf|

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -145,46 +145,46 @@ describe "handler" do
     }
 
     it "should return true if there is a 910 field with subfield tag of a and a value of RL" do
-      json_varfields = JSON.dump([{
+      varfields = [{
         'marcTag' => '910',
         'subfields' => [{ 'content' => 'RL', 'tag' => 'a' }]
-      }])
+      }]
 
-      expect(is_research?({'varFields' => json_varfields})).to eq(true)
+      expect(is_research?({'varFields' => varfields})).to eq(true)
     end
 
     it "should return false if there is a 910 field with subfield tag of a and a value of BL" do
-      json_varfields = JSON.dump([{
+      varfields = [{
         'marcTag' => '910',
         'subfields' => [{ 'content' => 'BL', 'tag' => 'a' }]
-      }])
+      }]
 
-      expect(is_research?({'varFields' => json_varfields})).to eq(false)
+      expect(is_research?({'varFields' => varfields})).to eq(false)
     end
 
     it "should return false if there is a 910 field with subfield tag of a and a value of anything else" do
-      json_varfields = JSON.dump([{
+      varfields = [{
         'marcTag' => '910',
         'subfields' => [{ 'content' => 'RLOTF', 'tag' => 'a' }]
-      }])
+      }]
 
-      expect(is_research?({'varFields' => json_varfields})).to eq(false)
+      expect(is_research?({'varFields' => varfields})).to eq(false)
     end
 
     # It's only the 910|a Marc field that we know is used for this. A 910 field with anything else could be 
     #   for a different purpose so it tells us nothing about the research status of this Bib
     it "should fallback to API if there is a 910 field with subfield tag other than a" do
-      json_varfields = JSON.dump([{
+      varfields = [{
         'marcTag' => '910',
         'subfields' => [{ 'content' => 'RL', 'tag' => 'z' }]
-      }])
+      }]
 
       expect($platform_api).to receive(:get).with('bibs/test-nypl/1/is-research').and_return({"isResearch" => true})
-      expect(is_research?({'id' => '1', 'nyplSource' => 'test-nypl', 'varFields' => json_varfields})).to eq(true)
+      expect(is_research?({'id' => '1', 'nyplSource' => 'test-nypl', 'varFields' => varfields})).to eq(true)
     end
 
     it "should take the first 910|a field if there are multiples (RL first test)" do
-      json_varfields = JSON.dump([
+      varfields = [
         {
           'marcTag' => '910',
           'subfields' => [{ 'content' => 'RL', 'tag' => 'a' }]
@@ -193,13 +193,13 @@ describe "handler" do
           'marcTag' => '910',
           'subfields' => [{ 'content' => 'BL', 'tag' => 'a' }]
         }
-      ])
+      ]
 
-      expect(is_research?({'varFields' => json_varfields})).to eq(true)
+      expect(is_research?({'varFields' => varfields})).to eq(true)
     end
 
     it "should take the first 910|a field if there are multiples (BL first test)" do
-      json_varfields = JSON.dump([
+      varfields = [
         {
           'marcTag' => '910',
           'subfields' => [{ 'content' => 'BL', 'tag' => 'a' }]
@@ -208,13 +208,13 @@ describe "handler" do
           'marcTag' => '910',
           'subfields' => [{ 'content' => 'RL', 'tag' => 'a' }]
         }
-      ])
+      ]
 
-      expect(is_research?({'varFields' => json_varfields})).to eq(false)
+      expect(is_research?({'varFields' => varfields})).to eq(false)
     end
 
     it "should ignore 910 without an 'a' subfield, processing a later one with an 'a' subfield" do
-      json_varfields = JSON.dump([
+      varfields = [
         {
           'marcTag' => '910',
           'subfields' => [{ 'content' => 'BL', 'tag' => 'b' }]
@@ -223,9 +223,9 @@ describe "handler" do
           'marcTag' => '910',
           'subfields' => [{ 'content' => 'RL', 'tag' => 'a' }]
         }
-      ])
+      ]
 
-      expect(is_research?({'varFields' => json_varfields})).to eq(true)
+      expect(is_research?({'varFields' => varfields})).to eq(true)
     end
 
     it "should return true if API response is true" do


### PR DESCRIPTION

**What's this do?**
Removes erroneous JSON processing

**Why are we doing this? (w/ JIRA link if applicable)**
Had misremembered which data fields were encoded in JSON (in the DB the varfields are, but not in the API response, obviously). My bad

**How should this be tested? / Do these changes have associated tests?**
Unit tests updated, but test events must be run. Full disclosure — not tried that yet.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
No, but will

